### PR TITLE
Multi layer sft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ logs
 log
 outputs
 .history
+*checkpoints*

--- a/create_hard_negatives_v2.py
+++ b/create_hard_negatives_v2.py
@@ -860,7 +860,9 @@ def main(
                     SentenceInfoV2.model_construct(max_act=max_act, tokens=tokens, act_tokens=token_activations)
                 )
 
-            pos_sae_activations = SAEActivationsV2(sae_id=feature_idx, sentences=pos_sentence_infos)
+            pos_sae_activations = SAEActivationsV2(
+                sae_id=feature_idx, sae_layer=sae_layer, sentences=pos_sentence_infos
+            )
 
             hard_negatives = []
 
@@ -897,7 +899,7 @@ def main(
                     )
 
                 hard_negative_sae_activations = SAEActivationsV2.model_construct(
-                    sae_id=similar_feature_idx, sentences=hard_negative_sentence_infos
+                    sae_id=similar_feature_idx, sae_layer=sae_layer, sentences=hard_negative_sentence_infos
                 )
                 hard_negatives.append(hard_negative_sae_activations)
 

--- a/detection_eval/detection_basemodels.py
+++ b/detection_eval/detection_basemodels.py
@@ -5,6 +5,14 @@ from pydantic import BaseModel
 from slist import Slist
 
 
+class SAEInfo(BaseModel):
+    sae_width: int
+    sae_layer: int
+    sae_layer_percent: int
+    sae_filename: str
+    sae_repo_id: str
+
+
 class TokenActivation(BaseModel):
     as_str: str
     activation: float
@@ -26,13 +34,11 @@ class SentenceInfo(BaseModel):
 
 class SAEActivations(BaseModel):
     sae_id: int
-    sae_layer: int = 9
     sentences: list[SentenceInfo]
 
 
 class SAE(BaseModel):
     sae_id: int
-    sae_layer: int = 9
     # feature_vector: Sequence[float]
     activations: SAEActivations
     # Sentences that do not activate for the given sae_id. But come from a similar SAE
@@ -67,13 +73,12 @@ class SentenceInfoV2(BaseModel):
 
 class SAEActivationsV2(BaseModel):
     sae_id: int
-    sae_layer: int = 9
     sentences: list[SentenceInfoV2]
 
 
 class SAEV2(BaseModel):
     sae_id: int
-    sae_layer: int = 9
+    sae_info: SAEInfo
     activations: SAEActivationsV2
     # Sentences that do not activate for the given sae_id. But come from a similar SAE
     # Here the sae_id correspond to different similar SAEs.
@@ -85,7 +90,6 @@ class SAEVerlDataTypedDict(TypedDict):
     """Typed dict that gets passed around in verl"""
 
     sae_id: int
-    sae_layer: int = 9
     feature_vector: list[float]  # This needs to be added in by the script
     position_id: int  # This needs to be added in by the script
     activations: dict[str, Any]
@@ -94,7 +98,6 @@ class SAEVerlDataTypedDict(TypedDict):
 
 class SAEVerlData(BaseModel):
     sae_id: int
-    sae_layer: int = 9
     feature_vector: list[float]  # This needs to be added in by the script
     position_id: int  # This needs to be added in by the script
     activations: SAEActivationsV2  # Sentences that should activate the feature

--- a/detection_eval/detection_basemodels.py
+++ b/detection_eval/detection_basemodels.py
@@ -26,11 +26,13 @@ class SentenceInfo(BaseModel):
 
 class SAEActivations(BaseModel):
     sae_id: int
+    sae_layer: int = 9
     sentences: list[SentenceInfo]
 
 
 class SAE(BaseModel):
     sae_id: int
+    sae_layer: int = 9
     # feature_vector: Sequence[float]
     activations: SAEActivations
     # Sentences that do not activate for the given sae_id. But come from a similar SAE
@@ -65,12 +67,13 @@ class SentenceInfoV2(BaseModel):
 
 class SAEActivationsV2(BaseModel):
     sae_id: int
+    sae_layer: int = 9
     sentences: list[SentenceInfoV2]
 
 
 class SAEV2(BaseModel):
     sae_id: int
-    sae_layer: int | None = None 
+    sae_layer: int = 9
     activations: SAEActivationsV2
     # Sentences that do not activate for the given sae_id. But come from a similar SAE
     # Here the sae_id correspond to different similar SAEs.
@@ -82,6 +85,7 @@ class SAEVerlDataTypedDict(TypedDict):
     """Typed dict that gets passed around in verl"""
 
     sae_id: int
+    sae_layer: int = 9
     feature_vector: list[float]  # This needs to be added in by the script
     position_id: int  # This needs to be added in by the script
     activations: dict[str, Any]
@@ -90,6 +94,7 @@ class SAEVerlDataTypedDict(TypedDict):
 
 class SAEVerlData(BaseModel):
     sae_id: int
+    sae_layer: int = 9
     feature_vector: list[float]  # This needs to be added in by the script
     position_id: int  # This needs to be added in by the script
     activations: SAEActivationsV2  # Sentences that should activate the feature

--- a/detection_eval/steering_hooks.py
+++ b/detection_eval/steering_hooks.py
@@ -6,7 +6,7 @@ import torch
 
 from detection_eval.detection_basemodels import SAEVerlDataTypedDict
 
-X_PROMPT = "You are currently introspecting your own activations. You need to describe to another model your activations mean. Here are your activations: 'X'. Explain what examples of positive sentences that have these activations. And what negative sentences don't have these activations (even if they look similar to the positives). Note that your activations can mean more than a single thing, so you should outline the different nuances of your activations and when and where sentences would be activated. Format your final answer with <explanation>"
+X_PROMPT = "You are currently introspecting your own activations from layer {sae_layer}. You need to describe to another model your activations mean. Here are your activations: 'X'. Explain what examples of positive sentences that have these activations. And what negative sentences don't have these activations (even if they look similar to the positives). Note that your activations can mean more than a single thing, so you should outline the different nuances of your activations and when and where sentences would be activated. Format your final answer with <explanation>"
 
 
 def get_vllm_steering_hook(

--- a/detection_eval/steering_hooks.py
+++ b/detection_eval/steering_hooks.py
@@ -6,7 +6,9 @@ import torch
 
 from detection_eval.detection_basemodels import SAEVerlDataTypedDict
 
-X_PROMPT = "You are currently introspecting your own activations from layer {sae_layer}. You need to describe to another model what your activations mean. Here are your activations: 'X'. Explain some examples of positive sentences that have these activations. And some examples of negative sentences that don't have these activations (even if they look similar to the positives). Note that your activations can mean more than a single thing, so you should outline the different nuances of your activations and when and where sentences would be activated. Format your final answer with <explanation>"
+def get_introspection_prompt(sae_layer: int) -> str:
+
+    return f"You are currently introspecting your own activations from layer {sae_layer}. You need to describe to another model what your activations mean. Here are your activations: 'X'. Explain some examples of positive sentences that have these activations. And some examples of negative sentences that don't have these activations (even if they look similar to the positives). Note that your activations can mean more than a single thing, so you should outline the different nuances of your activations and when and where sentences would be activated. Format your final answer with <explanation>"
 
 
 def get_vllm_steering_hook(

--- a/detection_eval/steering_hooks.py
+++ b/detection_eval/steering_hooks.py
@@ -7,8 +7,7 @@ import torch
 from detection_eval.detection_basemodels import SAEVerlDataTypedDict
 
 def get_introspection_prompt(sae_layer: int) -> str:
-
-    return f"You are currently introspecting your own activations from layer {sae_layer}. You need to describe to another model what your activations mean. Here are your activations: 'X'. Explain some examples of positive sentences that have these activations. And some examples of negative sentences that don't have these activations (even if they look similar to the positives). Note that your activations can mean more than a single thing, so you should outline the different nuances of your activations and when and where sentences would be activated. Format your final answer with <explanation>"
+    return f"Can you explain to me what 'X' means? It is from layer {sae_layer}. Format your final answer with <explanation>"
 
 
 def get_vllm_steering_hook(

--- a/detection_eval/steering_hooks.py
+++ b/detection_eval/steering_hooks.py
@@ -6,7 +6,7 @@ import torch
 
 from detection_eval.detection_basemodels import SAEVerlDataTypedDict
 
-X_PROMPT = "You are currently introspecting your own activations from layer {sae_layer}. You need to describe to another model your activations mean. Here are your activations: 'X'. Explain what examples of positive sentences that have these activations. And what negative sentences don't have these activations (even if they look similar to the positives). Note that your activations can mean more than a single thing, so you should outline the different nuances of your activations and when and where sentences would be activated. Format your final answer with <explanation>"
+X_PROMPT = "You are currently introspecting your own activations from layer {sae_layer}. You need to describe to another model what your activations mean. Here are your activations: 'X'. Explain some examples of positive sentences that have these activations. And some examples of negative sentences that don't have these activations (even if they look similar to the positives). Note that your activations can mean more than a single thing, so you should outline the different nuances of your activations and when and where sentences would be activated. Format your final answer with <explanation>"
 
 
 def get_vllm_steering_hook(

--- a/eval_detection_v2.py
+++ b/eval_detection_v2.py
@@ -24,7 +24,7 @@ from detection_eval.detection_basemodels import (
     SentenceInfoV2,
     TokenActivationV2,
 )
-from detection_eval.steering_hooks import X_PROMPT
+from detection_eval.steering_hooks import get_introspection_prompt
 
 
 class ModelInfo(BaseModel):
@@ -850,7 +850,7 @@ async def run_gemma_steering(
     """
     Run gemma steering for a single SAE.
     """
-    history = ChatHistory.from_user(X_PROMPT)
+    history = ChatHistory.from_user(get_introspection_prompt(sae_layer=9)) # TODO: FIX
     response = await gemma_caller.call(
         messages=history,
         config=InferenceConfig(
@@ -1008,6 +1008,7 @@ async def main(
         # Run gemma steering
         print("Running gemma steering")
         RUN_POD_URL = "https://728qdkul8ii0j5-8000.proxy.runpod.net/v1"
+        # RUN_POD_URL = "http://0.0.0.0:8000/v1"
         gemma_client = AsyncOpenAI(api_key="dummy api key", base_url=RUN_POD_URL)
         width = 131  # not cached by api call yet, so manually add to cache path
         gemma_caller = OpenAICaller(openai_client=gemma_client, cache_path=f"cache/steering_cache_{width}")

--- a/lightweight_sft.py
+++ b/lightweight_sft.py
@@ -1238,48 +1238,49 @@ if __name__ == "__main__":
     model_name = "Qwen/Qwen3-8B"
     hf_repo_name = "qwen3-8b-hook-layer-0"
 
-    cfg = SelfInterpTrainingConfig(
-        # Model settings
-        model_name=model_name,
-        train_batch_size=4,
-        eval_batch_size=128,  # 8 * 16
-        # SAE
-        # settings
-        hook_onto_layer=hook_layer,
-        sae_infos=[],
-        # Experiment settings
-        eval_set_size=100,
-        use_decoder_vectors=False,
-        generation_kwargs={
-            "do_sample": True,
-            "temperature": 1.0,
-            "max_new_tokens": 600,
-        },
-        steering_coefficient=2.0,
-        # LoRA settings
-        use_lora=True,
-        lora_r=64,
-        lora_alpha=128,
-        lora_dropout=0.05,
-        lora_target_modules="all-linear",
-        # Training settings
-        lr=2e-5,
-        eval_steps=99999999,
-        num_epochs=1,
-        save_steps=int(2000 / 4),  # save every 2000 samples
-        # num_epochs=4,
-        # save every epoch
-        # save_steps=math.ceil(len(explanations) / 4),
-        save_dir="checkpoints",
-        seed=42,
-        # Hugging Face settings - set these based on your needs
-        hf_push_to_hub=False,  # Only enable if login successful
-        hf_repo_id=False,
-        hf_private_repo=False,  # Set to False if you want public repo
-        positive_negative_examples=False,
-    )
 
-    for use_decoder_vectors in [True, False]:
+    for use_decoder_vectors in [False]:
+
+        cfg = SelfInterpTrainingConfig(
+            # Model settings
+            model_name=model_name,
+            train_batch_size=4,
+            eval_batch_size=128,  # 8 * 16
+            # SAE
+            # settings
+            hook_onto_layer=hook_layer,
+            sae_infos=[],
+            # Experiment settings
+            eval_set_size=100,
+            use_decoder_vectors=False,
+            generation_kwargs={
+                "do_sample": True,
+                "temperature": 1.0,
+                "max_new_tokens": 600,
+            },
+            steering_coefficient=2.0,
+            # LoRA settings
+            use_lora=True,
+            lora_r=64,
+            lora_alpha=128,
+            lora_dropout=0.05,
+            lora_target_modules="all-linear",
+            # Training settings
+            lr=2e-5,
+            eval_steps=99999999,
+            num_epochs=1,
+            save_steps=int(2000 / 4),  # save every 2000 samples
+            # num_epochs=4,
+            # save every epoch
+            # save_steps=math.ceil(len(explanations) / 4),
+            save_dir="checkpoints",
+            seed=42,
+            # Hugging Face settings - set these based on your needs
+            hf_push_to_hub=False,  # Only enable if login successful
+            hf_repo_id=False,
+            hf_private_repo=False,  # Set to False if you want public repo
+            positive_negative_examples=False,
+        )
         cfg.use_decoder_vectors = use_decoder_vectors
         if use_decoder_vectors:
             cfg.save_dir = f"checkpoints_decoder"

--- a/lightweight_sft.py
+++ b/lightweight_sft.py
@@ -20,7 +20,7 @@ Before running:
 
 import os
 
-from detection_eval.steering_hooks import X_PROMPT, add_hook, get_hf_activation_steering_hook
+from detection_eval.steering_hooks import add_hook, get_hf_activation_steering_hook, get_introspection_prompt
 
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
@@ -427,7 +427,7 @@ def build_training_prompt(positive_negative_examples: bool, sae_layer: int) -> s
     if positive_negative_examples:
         question = f"""Can you explain to me the concept of what 'X' from layer {sae_layer} means? Give positive and negative examples of what the concept would activate on. Format your final answer with <explanation>."""
     else:
-        question = X_PROMPT.format(sae_layer=sae_layer)
+        question = get_introspection_prompt(sae_layer)
     return question
 
 

--- a/sae_test.py
+++ b/sae_test.py
@@ -51,9 +51,10 @@ dtype = torch.bfloat16
 
 model_name = "Qwen/Qwen3-8B"
 
-model, tokenizer, sae, submodule = load_model_and_sae(
-    model_name, sae_repo_id, sae_info.sae_filename, sae_info.sae_layer
+model, tokenizer, sae = load_model_and_sae(
+    model_name, sae_repo_id, sae_info.sae_filename, sae_info.sae_layer, device, dtype
 )
+submodule = get_submodule(model, sae_info.sae_layer)  # type: ignore
 # %%
 max_acts_data = load_max_acts_data(
     model_name=model_name,

--- a/scripts/fix_data.py
+++ b/scripts/fix_data.py
@@ -1,0 +1,66 @@
+# %%
+
+raise ValueError("read details before running")
+
+# note: move this up to the verl dir before running. Backup your data before running, this script may have sharp edges
+
+# %%
+
+import json
+
+import pydantic
+from pydantic import BaseModel
+from tqdm import tqdm
+
+
+class SAEInfo(BaseModel):
+    sae_width: int
+    sae_layer: int
+    sae_layer_percent: int
+    sae_filename: str
+    sae_repo_id: str
+
+class SAEExplained(BaseModel):
+    sae_id: int
+    explanation: str
+    positive_examples: list[str]
+    negative_examples: list[str]
+    f1: float
+    sae_info: SAEInfo
+
+
+layer_percents = [25, 50, 75]
+
+
+for layer_percent in layer_percents:
+    filename = f"data/qwen_hard_negatives_0_20000_layer_percent_{layer_percent}_sft_data_gpt-5-mini-2025-08-07.jsonl"
+    good_sae_info_filename = f"data/qwen_hard_negatives_0_30_layer_percent_{layer_percent}.jsonl"
+
+    with open(good_sae_info_filename, "r") as f:
+        good_sae_info = [json.loads(line) for line in f]
+
+    sae_info = good_sae_info[0]["sae_info"]
+
+    all_data = []
+
+    with open(filename, "r") as f:
+        for line in tqdm(f, "loading"):
+            data = json.loads(line)
+            data["sae_info"] = sae_info
+            all_data.append(data)
+
+
+
+
+
+
+good_sae_info_filename
+
+with open(filenames[1], "r") as f:
+    data = [json.loads(line) for line in f]
+
+# %%
+
+print(data[0])
+
+# %%

--- a/scripts/fix_hard_negatives.py
+++ b/scripts/fix_hard_negatives.py
@@ -1,0 +1,93 @@
+# %%
+
+raise ValueError("read details before running")
+
+# note: move this up to the verl dir before running. Backup your data before running, this script may have sharp edges
+
+# %%
+
+from tqdm import tqdm
+import json
+
+good_filenames = [
+    "data_good/qwen_hard_negatives_0_20000_layer_percent_25.jsonl",
+    "data_good/qwen_hard_negatives_0_20000_layer_percent_50.jsonl",
+    "data_good/qwen_hard_negatives_0_20000_layer_percent_75.jsonl",
+]
+
+for good_filename in good_filenames:
+    good_sae_info_filename = good_filename.replace("data_good", "data").replace("20000", "30")
+
+    with open(good_sae_info_filename, "r") as f:
+        good_sae_info = [json.loads(line) for line in f]
+
+    sae_info = good_sae_info[0]["sae_info"]
+
+    all_data = []
+
+    max_lines = 30
+    max_lines = None
+
+    with open(good_filename, "r") as f:
+        for i, line in tqdm(enumerate(f), "loading"):
+            if max_lines is not None and i >= max_lines:
+                break
+
+            data = json.loads(line)
+
+            data["sae_info"] = sae_info
+
+            if "sae_layer" in data:
+                data.pop("sae_layer")
+
+            all_data.append(data)
+
+    with open(good_filename, "w") as f:
+        for i, data in tqdm(enumerate(all_data), "saving"):
+            if max_lines is not None and i >= max_lines:
+                break
+
+            f.write(json.dumps(data) + "\n")
+
+    print(f"Updated {good_filename}")
+
+# %%
+# %%
+
+# import json
+
+# good_filenames = [
+#     "data_good/qwen_hard_negatives_0_20000_layer_percent_25.jsonl",
+#     "data_good/qwen_hard_negatives_0_20000_layer_percent_50.jsonl",
+#     "data_good/qwen_hard_negatives_0_20000_layer_percent_75.jsonl",
+#     # "data_good/qwen_hard_negatives_0_20000_layer_percent_50_sft_data_gpt-5-mini-2025-08-07.jsonl",
+# ]
+
+# idx = 1
+
+# first_filename = good_filenames[idx]
+# good_sae_info_filename = good_filenames[idx].replace("data_good", "data").replace("20000", "30")
+
+# max_lines = 30
+# data = []
+# with open(good_filenames[idx], "r") as f:
+#     for i in range(max_lines):
+#         line = f.readline()
+#         if line == "":
+#             break
+#         data.append(json.loads(line))
+
+# with open(good_sae_info_filename, "r") as f:
+#     good_sae_info = [json.loads(line) for line in f]
+
+# # %%
+
+# print(good_sae_info[0].keys())
+# print(good_sae_info[0]["sae_info"])
+
+# print("__")
+# print(data[1].keys())
+# print(data[1]["sae_id"])
+# print(data[1]["sae_info"])
+
+# # %%


### PR DESCRIPTION
SAEV2 and SAEExplained now contain an SAEInfo object, that has all relevant SAE details. This will break backwards compatability. I added temp fix scripts in the scripts/ dir: https://github.com/thejaminator/verl/blob/multi-layer-sft/scripts/fix_data.py

I also modified X_PROMPT to also include the sae_layer. This will also break backwards compatibility, but using `get_introspection_prompt(sae_layer)` should fix it. I also began to slightly consolidate some core functionality like loading models, tokenizers, and saes (all are currently in create_hard_negatives_v2.py

